### PR TITLE
RDKEMW-12476 [RDKAppManager][PreinstallManager] packageList iterator should be freed - Fix

### DIFF
--- a/PreinstallManager/PreinstallManagerImplementation.cpp
+++ b/PreinstallManager/PreinstallManagerImplementation.cpp
@@ -372,14 +372,9 @@ namespace WPEFramework
                 // multiple apps possible with same packageId but different version
             }
 
-            if (packageList) {
-                LOGINFO("Releasing packageList iterator and pointing it to Nullptr");
-                packageList->Release();
-                packageList = nullptr;
-            }
-            else {
-                LOGWARN("packageList is already nullptr, skipping release");
-            }
+            packageList->Release();
+            packageList = nullptr;
+
             // filter to-be-installed apps
             for (auto toBeInstalledApp = preinstallPackages.begin(); toBeInstalledApp != preinstallPackages.end(); /* skip */)
             {

--- a/PreinstallManager/PreinstallManagerImplementation.cpp
+++ b/PreinstallManager/PreinstallManagerImplementation.cpp
@@ -354,7 +354,7 @@ namespace WPEFramework
             Core::hresult listResult = mPackageManagerInstallerObject->ListPackages(packageList);
             if (listResult != Core::ERROR_NONE || packageList == nullptr)
             {
-                 LOGERR("ListPackages failed with result %d or package list is null", static_cast<int32_t>(listResult));
+                 LOGERR("ListPackages failed or package list is null");
                 if (packageList != nullptr)
                 {
                     packageList->Release();

--- a/PreinstallManager/PreinstallManagerImplementation.cpp
+++ b/PreinstallManager/PreinstallManagerImplementation.cpp
@@ -351,9 +351,14 @@ namespace WPEFramework
             Exchange::IPackageInstaller::IPackageIterator *packageList = nullptr;
 
             // fetch installed packages
-            if (mPackageManagerInstallerObject->ListPackages(packageList) != Core::ERROR_NONE && packageList != nullptr)
+            if (mPackageManagerInstallerObject->ListPackages(packageList) != Core::ERROR_NONE || packageList == nullptr)
             {
                 LOGERR("ListPackage is returning Error or Packages is nullptr");
+                if (packageList != nullptr)
+                {
+                    packageList->Release();
+                    packageList = nullptr;
+                }
                 return result;
             }
 

--- a/PreinstallManager/PreinstallManagerImplementation.cpp
+++ b/PreinstallManager/PreinstallManagerImplementation.cpp
@@ -351,7 +351,8 @@ namespace WPEFramework
             Exchange::IPackageInstaller::IPackageIterator *packageList = nullptr;
 
             // fetch installed packages
-            if (mPackageManagerInstallerObject->ListPackages(packageList) != Core::ERROR_NONE || packageList == nullptr)
+            Core::hresult listResult = mPackageManagerInstallerObject->ListPackages(packageList);
+            if (listResult != Core::ERROR_NONE || packageList == nullptr)
             {
                 LOGERR("ListPackage is returning Error or Packages is nullptr");
                 if (packageList != nullptr)

--- a/PreinstallManager/PreinstallManagerImplementation.cpp
+++ b/PreinstallManager/PreinstallManagerImplementation.cpp
@@ -367,6 +367,14 @@ namespace WPEFramework
                 // multiple apps possible with same packageId but different version
             }
 
+            if (packageList) {
+                LOGINFO("Releasing packageList iterator and pointing it to Nullptr");
+                packageList->Release();
+                packageList = nullptr;
+            }
+            else {
+                LOGWARN("packageList is already nullptr, skipping release");
+            }
             // filter to-be-installed apps
             for (auto toBeInstalledApp = preinstallPackages.begin(); toBeInstalledApp != preinstallPackages.end(); /* skip */)
             {

--- a/PreinstallManager/PreinstallManagerImplementation.cpp
+++ b/PreinstallManager/PreinstallManagerImplementation.cpp
@@ -354,7 +354,7 @@ namespace WPEFramework
             Core::hresult listResult = mPackageManagerInstallerObject->ListPackages(packageList);
             if (listResult != Core::ERROR_NONE || packageList == nullptr)
             {
-                LOGERR("ListPackage is returning Error or Packages is nullptr");
+                 LOGERR("ListPackages failed with result %d or package list is null", static_cast<int32_t>(listResult));
                 if (packageList != nullptr)
                 {
                     packageList->Release();


### PR DESCRIPTION
Reason for change: packageList iterator should be freed otherwise, it will lead to memory leak.
Version: Minor
Test Procedure: None
Priority: P2
Risks: None
Signed-off-by: [devasenapriya_b@comcast.com]