### PR TITLE
RDKEMW-12488: StorageManager Error cases in configure method should clear the interface pointers

### DIFF
--- a/StorageManager/StorageManager.h
+++ b/StorageManager/StorageManager.h
@@ -53,6 +53,7 @@ namespace Plugin {
             uint32_t mConnectionId{};
             Exchange::IStorageManager* mStorageManagerImpl{};
             Exchange::IConfiguration* mConfigure{};
+            bool mRegistered{false};
 
         public /* constants */:
             static const string SERVICE_NAME;


### PR DESCRIPTION
Reason for change: In configure method, interface pointer should be released otherwise, it will lead to memory leak.
Version: Minor
Test Procedure: None
Priority: P2
Risks: None
Signed-off-by: [Jeyasona_Durairaj@comcast.com]