### PR TITLE
RDKEMW-12469 - protect member variables in LifecycleInterfaceConnector -testing

### DIFF
--- a/AppManager/AppManagerImplementation.cpp
+++ b/AppManager/AppManagerImplementation.cpp
@@ -232,16 +232,19 @@ void AppManagerImplementation::dispatchEvent(EventNames event, const JsonObject 
 
 void AppManagerImplementation::Dispatch(EventNames event, const JsonObject params)
 {
+    string appId = "";
+    string appInstanceId = "";
+    AppLifecycleState newState = Exchange::IAppManager::AppLifecycleState::APP_STATE_UNKNOWN;
+    AppLifecycleState oldState = Exchange::IAppManager::AppLifecycleState::APP_STATE_UNKNOWN;
+    AppErrorReason errorReason = Exchange::IAppManager::AppErrorReason::APP_ERROR_NONE;
+    string version = "";
+    string installStatus = "";
+    string intent = "";
+    string source = "";
     switch(event)
     {
         case APP_EVENT_LIFECYCLE_STATE_CHANGED:
         {
-            string appId = "";
-            string appInstanceId = "";
-            AppLifecycleState newState = Exchange::IAppManager::AppLifecycleState::APP_STATE_UNKNOWN;
-            AppLifecycleState oldState = Exchange::IAppManager::AppLifecycleState::APP_STATE_UNKNOWN;
-            AppErrorReason errorReason = Exchange::IAppManager::AppErrorReason::APP_ERROR_NONE;
-
             if (!(params.HasLabel("appId") && !(appId = params["appId"].String()).empty()))
             {
                 LOGERR("appId not present or empty");
@@ -275,9 +278,6 @@ void AppManagerImplementation::Dispatch(EventNames event, const JsonObject param
         }
         case APP_EVENT_INSTALLATION_STATUS:
         {
-            string appId = "";
-            string version = "";
-            string installStatus = "";
             /* Check if 'packageId' exists and is not empty */
             appId = params.HasLabel("packageId") ? params["packageId"].String() : "";
             if (appId.empty())
@@ -316,10 +316,6 @@ void AppManagerImplementation::Dispatch(EventNames event, const JsonObject param
         }
         case APP_EVENT_LAUNCH_REQUEST:
         {
-            string appId = "";
-            string intent = "";
-            string source = "";
-
             appId = params.HasLabel("appId") ? params["appId"].String() : "";
             if (appId.empty())
             {
@@ -348,9 +344,6 @@ void AppManagerImplementation::Dispatch(EventNames event, const JsonObject param
         }
         case APP_EVENT_UNLOADED:
         {
-            string appId = "";
-            string appInstanceId = "";
-
             appId = params.HasLabel("appId") ? params["appId"].String() : "";
             if (appId.empty())
             {
@@ -704,6 +697,7 @@ bool AppManagerImplementation::removeAppInfoByAppId(const string &appId)
 {
     bool result = false;
 
+    Core::SafeSyncType<Core::CriticalSection> lock(mAdminLock);
     /* Check if appId StorageInfo is found, erase it */
     auto it = mAppInfo.find(appId);
     if (it != mAppInfo.end())

--- a/AppManager/AppManagerImplementation.cpp
+++ b/AppManager/AppManagerImplementation.cpp
@@ -1659,5 +1659,24 @@ bool AppManagerImplementation::checkInstallUninstallBlock(const std::string& app
     LOGINFO("checkInstallUninstallBlock: appId=%s duplicateCount=%d blocked=%d", appId.c_str(), duplicateCount, blocked);
     return blocked;
 }
+bool AppManagerImplementation::getAppinfo(const string& appId,AppInfo &appData){
+    mAdminLock.Lock();
+    auto it = mAppInfo.find(appId);
+    bool found =false;
+    if((it != mAppInfo.end()))
+    {
+        appData=it->second;
+        LOGINFO("Fetched appData for appId %s", appId.c_str());
+         found = true;
+    }
+    else
+    {
+        LOGERR("Failed to fetch appData for appId %s", appId.c_str());
+    }
+    mAdminLock.Unlock();
+    return found;
+   
+}
+
 } /* namespace Plugin */
 } /* namespace WPEFramework */

--- a/AppManager/AppManagerImplementation.h
+++ b/AppManager/AppManagerImplementation.h
@@ -233,6 +233,7 @@ namespace Plugin {
 
         // IConfiguration methods
         uint32_t Configure(PluginHost::IShell* service) override;
+        bool getAppinfo(const string& appId,AppInfo &appData);
 
     private: /* private methods */
         Core::hresult createPersistentStoreRemoteStoreObject();

--- a/AppManager/LifecycleInterfaceConnector.cpp
+++ b/AppManager/LifecycleInterfaceConnector.cpp
@@ -78,7 +78,10 @@ namespace WPEFramework
             LifecycleInterfaceConnector::_instance = nullptr;
 
 	    //clear action list
-	    mAppCurrentActionList.clear();
+	    {
+	        Core::SafeSyncType<Core::CriticalSection> lock(mAdminLock);
+	        mAppCurrentActionList.clear();
+	    }
         }
 
         Core::hresult LifecycleInterfaceConnector::createLifecycleManagerRemoteObject()
@@ -367,10 +370,10 @@ namespace WPEFramework
 
             if(nullptr != appManagerImplInstance)
             {
-                for(auto appIterator = appManagerImplInstance->mAppInfo.begin(); appIterator != appManagerImplInstance->mAppInfo.end(); ++appIterator)
+                // Use find instead of iteration to avoid iterator invalidation issues
+                auto appIterator = appManagerImplInstance->mAppInfo.find(appId);
+                if(appIterator != appManagerImplInstance->mAppInfo.end())
                 {
-                    if(appIterator->first.compare(appId) == 0)
-                    {
                         appInstanceId = appIterator->second.appInstanceId;
                         appIntent = appIterator->second.appIntent;
                         isAppLoaded = true;
@@ -474,9 +477,6 @@ namespace WPEFramework
                             appManagerTelemetryReporting.reportTelemetryErrorData(appId, AppManagerImplementation::APP_ACTION_CLOSE, AppManagerImplementation::ERROR_INTERNAL);
 #endif
                         }
-
-                        break;
-                    }
                 }
 
                 if (!isAppLoaded)
@@ -517,10 +517,10 @@ namespace WPEFramework
             mAdminLock.Lock();
             if (nullptr != appManagerImplInstance)
             {
-                for ( std::map<std::string, AppManagerImplementation::AppInfo>::iterator appIterator = appManagerImplInstance->mAppInfo.begin(); appIterator != appManagerImplInstance->mAppInfo.end(); appIterator++)
+                // Use find instead of iteration to avoid iterator invalidation issues
+                auto appIterator = appManagerImplInstance->mAppInfo.find(appId);
+                if (appIterator != appManagerImplInstance->mAppInfo.end())
                 {
-                    if (appIterator->first.compare(appId) == 0)
-                    {
                         foundAppId = true;
                         appInstanceId = appIterator->second.appInstanceId;
                         if (nullptr != mLifecycleManagerRemoteObject)
@@ -536,8 +536,6 @@ namespace WPEFramework
 #endif
                             }
                         }
-                        break;
-                    }
                 }
                 if (!foundAppId)
                 {
@@ -816,11 +814,10 @@ End:
             if(nullptr != appManagerImplInstance)
             {
                 Core::SafeSyncType<Core::CriticalSection> lock(mAdminLock);
-                std::map<std::string, AppManagerImplementation::AppInfo>::iterator it;
-                for (it = appManagerImplInstance->mAppInfo.begin(); it != appManagerImplInstance->mAppInfo.end(); ++it)
+                // Use find instead of iteration to avoid iterator invalidation issues
+                auto it = appManagerImplInstance->mAppInfo.find(appId);
+                if (it != appManagerImplInstance->mAppInfo.end() && it->second.appInstanceId.compare(appInstanceId) == 0)
                 {
-                    if((it->first.compare(appId) == 0) && (it->second.appInstanceId.compare(appInstanceId) == 0))
-                    {
                         it->second.appOldState = oldAppState;
                         it->second.appNewState = newAppState;
                         it->second.appLifecycleState = newState;
@@ -853,8 +850,6 @@ End:
                                 mStateChangedCV.notify_all();
                             }
                         }
-                        break;
-                    }
                 }
                 shouldNotify = ((newAppState == Exchange::IAppManager::AppLifecycleState::APP_STATE_LOADING) ||
                                        (newAppState == Exchange::IAppManager::AppLifecycleState::APP_STATE_ACTIVE) ||
@@ -869,7 +864,8 @@ End:
                 {
                     if(newAppState == Exchange::IAppManager::AppLifecycleState::APP_STATE_UNLOADED)
 		    {
-                        if (mAppCurrentActionList[appId] == Exchange::IAppManager::AppLifecycleState::APP_STATE_TERMINATING)
+                        auto actionIt = mAppCurrentActionList.find(appId);
+                        if (actionIt != mAppCurrentActionList.end() && actionIt->second == Exchange::IAppManager::AppLifecycleState::APP_STATE_TERMINATING)
 			{
 			    //Normal close: Unlode event from App manager
 			    LOGINFO("Terminate event from plugin");
@@ -881,7 +877,10 @@ End:
 			    LOGINFO("Terminate event due to app crash");
 			    appManagerImplInstance->handleOnAppLifecycleStateChanged(appId, appInstanceId, newAppState, oldAppState, Exchange::IAppManager::AppErrorReason::APP_ERROR_ABORT);
 			}
-			mAppCurrentActionList.erase(appId);
+			if (actionIt != mAppCurrentActionList.end())
+			{
+			    mAppCurrentActionList.erase(actionIt);
+			}
 		    }
 		    else
 		    {
@@ -985,6 +984,7 @@ End:
             if (!appManagerImpl)
                 return;
 
+            Core::SafeSyncType<Core::CriticalSection> lock(mAdminLock);
             auto it = appManagerImpl->mAppInfo.find(appId);
             if (it != appManagerImpl->mAppInfo.end())
             {


### PR DESCRIPTION
1. In LifecycleInterfaceConnector.cpp, Map accessed without synchronization in multiple places. Data race and map corruption is possible.
2. Iterating over map while it could be modified. Iterator invalidation; crash or undefined behavior.
3. In AppManagerImplementation.cpp, Dispatch() method have same variables declared for each cases. This can be moved to the API entry point. Please review the code and check the feasibility of the Windsurf suggession.