### PR TITLE
RDKMVE-1983: fix APP_ERROR_PACKAGE_LOCK preventing app launch

### DIFF
--- a/AppManager/AppManagerImplementation.cpp
+++ b/AppManager/AppManagerImplementation.cpp
@@ -155,6 +155,8 @@ void AppManagerImplementation::AppManagerWorkerThread(void)
                                         if (status != Core::ERROR_NONE)
                                         {
                                             LOGERR("launch failed status %d", status);
+                                            Core::hresult unlockStatus = packageUnLock(appId);
+                                            LOGWARN("package unlock after launch failure for appId %s status %d", appId.c_str(), unlockStatus);
                                         }
                                     }
                                     else if (action == APP_ACTION_PRELOAD)
@@ -166,6 +168,8 @@ void AppManagerImplementation::AppManagerWorkerThread(void)
                                         if ((!errorReason.empty()) || (status != Core::ERROR_NONE))
                                         {
                                             LOGERR("preLoadApp failed reason %s status %d", errorReason.c_str(), status);
+                                            Core::hresult unlockStatus = packageUnLock(appId);
+                                            LOGWARN("package unlock after preload failure for appId %s status %d", appId.c_str(), unlockStatus);
                                         }
                                     }
                                 }
@@ -797,6 +801,9 @@ Core::hresult AppManagerImplementation::packageLock(const string& appId, Package
                         if (!result)
                         {
                             LOGERR("Failed to createOrUpdate the PackageInfo");
+                            Core::hresult unlockStatus = mPackageManagerHandlerObject->Unlock(appId, packageData.version);
+                            LOGWARN("Rollback unlock for appId %s version %s returned status %d",
+                                    appId.c_str(), packageData.version.c_str(), unlockStatus);
 #ifdef ENABLE_AIMANAGERS_TELEMETRY_METRICS
                             appManagerTelemetryReporting.reportTelemetryErrorData(appId, AppManagerImplementation::APP_ACTION_LAUNCH, AppManagerImplementation::ERROR_PACKAGE_INVALID);
 #endif
@@ -810,6 +817,12 @@ Core::hresult AppManagerImplementation::packageLock(const string& appId, Package
                         appManagerTelemetryReporting.reportTelemetryErrorData(appId, AppManagerImplementation::APP_ACTION_LAUNCH, AppManagerImplementation::ERROR_PACKAGE_LOCK);
 #endif
                         packageData.version.clear();  /* Clear version on failure */
+                    }
+
+                    if (appMetadata != nullptr)
+                    {
+                        appMetadata->Release();
+                        appMetadata = nullptr;
                     }
                 }
                 else

--- a/PackageManager/PackageManagerImplementation.cpp
+++ b/PackageManager/PackageManagerImplementation.cpp
@@ -764,6 +764,14 @@ namespace Plugin {
                     if (result == packagemanager::SUCCESS) {
                         state.runtimeConfig.runtimePath = config.runtimePath;   // XXX: find better way
                         LOGDBG("Locked runtime. id: %s:%s ", rtPackageId.c_str(), rtVersion.c_str());
+                    } else {
+                        LOGERR("Failed to lock runtime. Rolling back app lock for %s:%s", packageId.c_str(), version.c_str());
+                        Core::hresult unlockResult = UnlockPackage(packageId, version);
+                        if (unlockResult != Core::ERROR_NONE) {
+                            LOGERR("Rollback app unlock failed for %s:%s", packageId.c_str(), version.c_str());
+                        }
+                        state.additionalLocks.clear();
+                        return result;
                     }
                     #else
                         LOGWARN("Not runtime locking in old libpackage");

--- a/Tests/L1Tests/tests/test_AppManager.cpp
+++ b/Tests/L1Tests/tests/test_AppManager.cpp
@@ -1293,6 +1293,57 @@ TEST_F(AppManagerTest, LaunchAppUsingComRpcFailureIsAppLoadedReturnError)
 }
 
 /*
+ * Test Case for LaunchAppUsingComRpcFailurePackageInfoUpdateRollbackUnlock
+ * Setting up AppManager/LifecycleManager/PackageManager resources and creating required COM-RPC resources
+ * Simulating successful PackageManager Lock with empty unpacked path to force createOrUpdatePackageInfoByAppId failure
+ * Verifying PackageManager Unlock is called for rollback and lifecycle error notification is sent
+ */
+TEST_F(AppManagerTest, LaunchAppUsingComRpcFailurePackageInfoUpdateRollbackUnlock)
+{
+    Core::hresult status;
+    uint32_t signalled = AppManager_StateInvalid;
+    Core::Sink<NotificationHandler> notification;
+    ExpectedAppLifecycleEvent expectedEvent;
+
+    status = createResources();
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    expectedEvent.appId = APPMANAGER_APP_ID;
+    expectedEvent.appInstanceId = "";
+    expectedEvent.newState = Exchange::IAppManager::AppLifecycleState::APP_STATE_UNKNOWN;
+    expectedEvent.oldState = Exchange::IAppManager::AppLifecycleState::APP_STATE_UNLOADED;
+    expectedEvent.errorReason = Exchange::IAppManager::AppErrorReason::APP_ERROR_PACKAGE_LOCK;
+    mAppManagerImpl->Register(&notification);
+    notification.SetExpectedEvent(expectedEvent);
+
+    LaunchAppPreRequisite(Exchange::ILifecycleManager::LifecycleState::ACTIVE);
+
+    EXPECT_CALL(*mPackageManagerMock, Lock(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_))
+    .WillOnce([&](const string &, const string &, const Exchange::IPackageHandler::LockReason &, uint32_t &lockId,
+                  string &unpackedPath, Exchange::RuntimeConfig &, Exchange::IPackageHandler::ILockIterator *&appMetadata) {
+        lockId = 7;
+        unpackedPath = "";
+        appMetadata = nullptr;
+        return Core::ERROR_NONE;
+    });
+
+    EXPECT_CALL(*mPackageManagerMock, Unlock(APPMANAGER_APP_ID, APPMANAGER_APP_VERSION))
+    .Times(1)
+    .WillOnce(::testing::Return(Core::ERROR_NONE));
+
+    EXPECT_EQ(Core::ERROR_NONE, mAppManagerImpl->LaunchApp(APPMANAGER_APP_ID, APPMANAGER_APP_INTENT, APPMANAGER_APP_LAUNCHARGS));
+
+    signalled = notification.WaitForRequestStatus(TIMEOUT, AppManager_onAppLifecycleStateChanged);
+    EXPECT_TRUE(signalled & AppManager_onAppLifecycleStateChanged);
+
+    mAppManagerImpl->Unregister(&notification);
+    if (status == Core::ERROR_NONE)
+    {
+        releaseResources();
+    }
+}
+
+/*
  * Test Case for LaunchAppUsingComRpcFailureLifecycleManagerRemoteObjectIsNull
  * Setting up only AppManager Plugin and creating required COM-RPC resources
  * LifecycleManager Interface object is not created and hence the API should return error

--- a/Tests/L1Tests/tests/test_PackageManager.cpp
+++ b/Tests/L1Tests/tests/test_PackageManager.cpp
@@ -1759,3 +1759,54 @@ TEST_F(PackageManagerTest, unlockmethodusingComRpcFailure) {
 
 	deinitforComRpc();
 }
+
+/* Test Case for lock rollback on runtime lock failure using ComRpc
+ *
+ * Initialize COM-RPC resources and seed package state with an already locked app package
+ * Configure runtime dependency to a missing runtime package so runtime lock fails
+ * Verify Lock returns failure and app package lock count is rolled back to original value
+ */
+TEST_F(PackageManagerTest, lockmethodusingComRpcFailureRuntimeLockRollback) {
+
+    initforComRpc();
+
+    const string appId = "com.test.rollback.app";
+    const string version = "1.0.0";
+    const string runtimeId = "com.test.rollback.runtime";
+    const string runtimeVersion = "9.9.9";
+
+    waitforSignal(TIMEOUT_FOR_INIT);
+
+    Plugin::PackageManagerImplementation::State appState;
+    appState.installState = Exchange::IPackageInstaller::InstallState::INSTALLED;
+    appState.mLockCount = 1;
+    appState.runtimeApp = {runtimeId, runtimeVersion};
+
+    {
+        std::lock_guard<std::recursive_mutex> lock(mPackageManagerImpl->mtxState);
+        mPackageManagerImpl->cacheInitialized = true;
+        mPackageManagerImpl->mState[{appId, version}] = appState;
+    }
+
+    uint32_t lockId = 0;
+    string unpackedPath;
+    Exchange::RuntimeConfig runtimeConfig;
+    Exchange::IPackageHandler::ILockIterator* appMetadata = nullptr;
+
+    Core::hresult status = pkghandlerInterface->Lock(
+        appId, version, Exchange::IPackageHandler::LockReason::LAUNCH,
+        lockId, unpackedPath, runtimeConfig, appMetadata);
+
+    EXPECT_NE(Core::ERROR_NONE, status);
+    EXPECT_EQ(nullptr, appMetadata);
+
+    {
+        std::lock_guard<std::recursive_mutex> lock(mPackageManagerImpl->mtxState);
+        auto it = mPackageManagerImpl->mState.find({appId, version});
+        ASSERT_NE(it, mPackageManagerImpl->mState.end());
+        EXPECT_EQ(1u, it->second.mLockCount);
+    }
+
+    deinitforComRpc();
+}
+


### PR DESCRIPTION
Reason For Change: A lock lifecycle mismatch caused sticky package locks. Launches could acquire shared locks, fail later, and skip releasing some locks. Repeated attempts accumulated lock counts until APP_ERROR_PACKAGE_LOCK occurred, and only a reboot (clearing process memory state) reset the condition.