### PR TITLE
L1 test for RalfSupport (DO NOT MERGE)

### DIFF
--- a/Tests/L1Tests/CMakeLists.txt
+++ b/Tests/L1Tests/CMakeLists.txt
@@ -220,3 +220,12 @@ if(BUILD_L1_TESTS_SHARED_MODULE)
     install(TARGETS ${MODULE_NAME} DESTINATION lib)
     write_config(${PLUGIN_NAME})
 endif()
+
+
+add_executable(test_RalfSupport test_RalfSupport.cpp)
+
+target_link_libraries(test_RalfSupport
+    gtest
+    gtest_main
+    pthread
+)

--- a/Tests/L1Tests/CMakeLists.txt
+++ b/Tests/L1Tests/CMakeLists.txt
@@ -229,3 +229,11 @@ target_link_libraries(test_RalfSupport
     gtest_main
     pthread
 )
+
+add_executable(test_RalfPackageBuilder_L2 test_RalfPackageBuilder_L2.cpp)
+
+target_link_libraries(test_RalfPackageBuilder_L2
+    gtest
+    gtest_main
+    pthread
+)

--- a/Tests/L1Tests/test_RalfPackageBuilder_L2.cpp
+++ b/Tests/L1Tests/test_RalfPackageBuilder_L2.cpp
@@ -1,0 +1,44 @@
+#include <gtest/gtest.h>
+#include "RalfPackageBuilder.h"
+#include "RalfSupport.h"
+#include <fstream>
+
+using namespace ralf;
+
+
+// L2 TEST: Full integration flow
+
+TEST(RalfPackageBuilderL2Test, GenerateDobbySpecBasicFlow)
+{
+    // Step 1: Create dummy JSON config file
+    std::ofstream file("ralf_pkg.json");
+    file << R"({
+        "packages": [
+            {
+                "pkgMetaDataPath": "meta1",
+                "pkgMountPath": "/mnt/pkg1"
+            }
+        ]
+    })";
+    file.close();
+
+    // Step 2: Prepare runtimeConfigObject
+    WPEFramework::Exchange::RuntimeConfig runtimeConfig;
+    runtimeConfig.ralfPkgPath = "ralf_pkg.json";
+
+    // Step 3: Prepare ApplicationConfiguration
+    WPEFramework::Plugin::ApplicationConfiguration config;
+    config.mAppInstanceId = "testApp";
+    config.mUserId = 1000;
+    config.mGroupId = 1000;
+
+    RalfPackageBuilder builder;
+
+    std::string dobbySpec;
+
+    // Step 4: Call main function
+    bool result = builder.generateRalfDobbySpec(config, runtimeConfig, dobbySpec);
+
+    // Step 5: Validate behavior
+    EXPECT_TRUE(result);
+}

--- a/Tests/L1Tests/test_RalfSupport.cpp
+++ b/Tests/L1Tests/test_RalfSupport.cpp
@@ -1,0 +1,38 @@
+#include <gtest/gtest.h>
+#include "RalfSupport.h"
+#include <fstream>
+
+using namespace ralf;
+
+TEST(ParseMemorySizeTest, Valid)
+{
+    EXPECT_EQ(parseMemorySize("512"), 512);
+    EXPECT_EQ(parseMemorySize("1K"), 1024);
+    EXPECT_EQ(parseMemorySize("1M"), 1024 * 1024);
+}
+
+TEST(ParseMemorySizeTest, Invalid)
+{
+    EXPECT_EQ(parseMemorySize(""), 0);
+    EXPECT_EQ(parseMemorySize("abc"), 0);
+}
+
+TEST(CheckPathExistsTest, Basic)
+{
+    std::ofstream f("temp.txt");
+    f << "data";
+    f.close();
+
+    EXPECT_TRUE(checkIfPathExists("temp.txt"));
+
+    remove("temp.txt");
+}
+
+TEST(SerializeJsonTest, Basic)
+{
+    Json::Value root;
+    root["key"] = "value";
+
+    std::string out = serializeJsonNode(root);
+    EXPECT_NE(out.find("key"), std::string::npos);
+}


### PR DESCRIPTION
Added L1 test for RalfSupport utility functions.

Changes:
- Created test file: test_RalfSupport.cpp
- Added basic test cases for:
  - parseMemorySize
  - checkIfPathExists
  - serializeJsonNode

Notes:
- This PR is created for learning and practice purposes.
- (DO NOT MERGE)