### PR TITLE
Enhance lifecycle state handling in AppManager and LifecycleManager

### DIFF
--- a/AppManager/AppManager.md
+++ b/AppManager/AppManager.md
@@ -242,6 +242,11 @@ flowchart TD
 
 Emitted when an application's lifecycle state changes.
 
+Lifecycle classification in `LifecycleInterfaceConnector::OnAppLifecycleStateChanged`:
+
+- `APP_STATE_UNLOADED` is emitted with `APP_ERROR_NONE` when termination follows an expected terminate path (`APP_STATE_TERMINATING -> APP_STATE_UNLOADED`) or when AppManager initiated terminate/kill/close.
+- `APP_STATE_UNLOADED` is emitted with `APP_ERROR_ABORT` when LifecycleManager reports an explicit abort error (`ERROR_ABORT`) before unload (for example, unexpected container termination/crash).
+
 ```json
 {
     "appId": "com.example.app",

--- a/AppManager/LifecycleInterfaceConnector.cpp
+++ b/AppManager/LifecycleInterfaceConnector.cpp
@@ -795,27 +795,55 @@ End:
                 {
                     if(Exchange::IAppManager::AppLifecycleState::APP_STATE_UNLOADED == newAppState)
 		    {
-                        const bool appManagerInitiatedKill = (Exchange::IAppManager::AppLifecycleState::APP_STATE_TERMINATING == mAppCurrentActionList[appId]);
-                        const bool lifecycleManagerInitiatedKill = (Exchange::IAppManager::AppLifecycleState::APP_STATE_TERMINATING == oldAppState);
-                        if (appManagerInitiatedKill || lifecycleManagerInitiatedKill)
+                        bool crashAbortPending = false;
+                        auto pendingCrashAbortIter = mPendingCrashAbortByAppId.find(appId);
+                        if ((mPendingCrashAbortByAppId.end() != pendingCrashAbortIter) && (true == pendingCrashAbortIter->second))
+                        {
+                            crashAbortPending = true;
+                            mPendingCrashAbortByAppId.erase(pendingCrashAbortIter);
+                        }
+
+                        bool appManagerInitiatedKill = false;
+                        auto appActionIter = mAppCurrentActionList.find(appId);
+                        if ((mAppCurrentActionList.end() != appActionIter) &&
+                            (Exchange::IAppManager::AppLifecycleState::APP_STATE_TERMINATING == appActionIter->second))
+                        {
+                            appManagerInitiatedKill = true;
+                        }
+
+                        const bool lifecycleManagerInitiatedKill =
+                            (Exchange::IAppManager::AppLifecycleState::APP_STATE_TERMINATING == oldAppState);
+
+
+                        if (crashAbortPending)
 			{
-			    //Normal close: Unload event from App manager or LifecycleManager-initiated kill (e.g. KILL_AND_RUN)
+			    LOGINFO("Terminate event due to app crash");
+			    appManagerImplInstance->handleOnAppLifecycleStateChanged(appId, appInstanceId, newAppState, oldAppState, Exchange::IAppManager::AppErrorReason::APP_ERROR_ABORT);
+                            const std::string storedInstanceId = AppInfoManager::getInstance().getAppInstanceId(appId);
+                            if (false == storedInstanceId.empty())
+                            {
+                                std::string crashReason = "Terminate event due to app crash";
+                                AppManagerTelemetryReporting::getInstance().reportAppCrashedTelemetry(appId, storedInstanceId, crashReason);
+                            }
+			}
+                        else if (appManagerInitiatedKill || lifecycleManagerInitiatedKill)
+			{
+			    // Normal close: AppManager requested termination or LifecycleManager terminated via close flow.
 			    LOGINFO("Terminate event from plugin");
 			    appManagerImplInstance->handleOnAppLifecycleStateChanged(appId, appInstanceId, newAppState, oldAppState, Exchange::IAppManager::AppErrorReason::APP_ERROR_NONE);
 			}
 			else
 			{
-			    //Abnormal close: No unload event from app manager
+			    // Abnormal close: unload did not originate from close/terminate flow.
 			    LOGINFO("Terminate event due to app crash");
 			    appManagerImplInstance->handleOnAppLifecycleStateChanged(appId, appInstanceId, newAppState, oldAppState, Exchange::IAppManager::AppErrorReason::APP_ERROR_ABORT);
-                // Report crash telemetry when lifecycle event provides a valid app instance id.
                 const std::string storedInstanceId = AppInfoManager::getInstance().getAppInstanceId(appId);
                 if (false == storedInstanceId.empty())
                 {
                     std::string crashReason = "Terminate event due to app crash";
                     AppManagerTelemetryReporting::getInstance().reportAppCrashedTelemetry(appId, storedInstanceId, crashReason);
                 }
-			}
+            }
 			mAppCurrentActionList.erase(appId);
 		    }
 		    else
@@ -866,9 +894,20 @@ End:
                 if (!errorReason.empty())
                 {
                     errorCode = mapErrorReason(errorReason);
-                    appManagerImplInstance->handleOnAppLifecycleStateChanged(appId, appInstanceId, Exchange::IAppManager::AppLifecycleState::APP_STATE_UNLOADED,
-                        currentAppState, errorCode);
-                    LOGINFO("Notified error event for appId %s: currentAppState=%d errorCode %d", appId.c_str(), static_cast<int>(currentAppState), static_cast<int>(errorCode));
+
+                    if (Exchange::IAppManager::AppErrorReason::APP_ERROR_ABORT == errorCode)
+                    {
+                        mAdminLock.Lock();
+                        mPendingCrashAbortByAppId[appId] = true;
+                        mAdminLock.Unlock();
+                        LOGINFO("Marked pending crash-abort for appId %s", appId.c_str());
+                    }
+                    else
+                    {
+                        appManagerImplInstance->handleOnAppLifecycleStateChanged(appId, appInstanceId, Exchange::IAppManager::AppLifecycleState::APP_STATE_UNLOADED,
+                            currentAppState, errorCode);
+                        LOGINFO("Notified error event for appId %s: currentAppState=%d errorCode %d", appId.c_str(), static_cast<int>(currentAppState), static_cast<int>(errorCode));
+                    }
                 }
             }
         }
@@ -889,6 +928,10 @@ End:
                 else if(!errorReason.compare("ERROR_INVALID_PARAM"))
                 {
                     errorCode = Exchange::IAppManager::AppErrorReason::APP_ERROR_INVALID_PARAM;
+                }
+                else if(!errorReason.compare("ERROR_ABORT"))
+                {
+                    errorCode = Exchange::IAppManager::AppErrorReason::APP_ERROR_ABORT;
                 }
                 else
                 {

--- a/AppManager/LifecycleInterfaceConnector.cpp
+++ b/AppManager/LifecycleInterfaceConnector.cpp
@@ -725,7 +725,7 @@ End:
 
         void LifecycleInterfaceConnector::OnAppLifecycleStateChanged(const string& appId, const string& appInstanceId, const Exchange::ILifecycleManager::LifecycleState oldState, const Exchange::ILifecycleManager::LifecycleState newState, const string& navigationIntent)
         {
-            AppManagerImplementation*appManagerImplInstance = AppManagerImplementation::getInstance();
+            AppManagerImplementation *appManagerImplInstance = AppManagerImplementation::getInstance();
             Exchange::IAppManager::AppLifecycleState oldAppState = mapAppLifecycleState(oldState);
             Exchange::IAppManager::AppLifecycleState newAppState = mapAppLifecycleState(newState);
             bool shouldNotify = false;
@@ -739,11 +739,12 @@ End:
                 return;
             }
 
-            if(nullptr != appManagerImplInstance)
+            if (nullptr != appManagerImplInstance)
             {
                 Core::SafeSyncType<Core::CriticalSection> lock(mAdminLock);
                 bool notifyPauseCV = false;
-                AppInfoManager::getInstance().update(appId, [&](AppInfo& a) {
+                AppInfoManager::getInstance().update(appId, [&](AppInfo &a)
+                                                     {
                     if (a.getAppInstanceId() == appInstanceId)
                     {
                         a.setAppOldState(oldAppState);
@@ -775,26 +776,25 @@ End:
                             if (mAppIdAwaitingPause == appId)
                                 notifyPauseCV = true;
                         }
-                    }
-                });
+                    } });
                 if (notifyPauseCV)
                 {
                     std::lock_guard<std::mutex> lk(mStateMutex);
                     mStateChangedCV.notify_all();
                 }
                 shouldNotify = ((Exchange::IAppManager::AppLifecycleState::APP_STATE_LOADING == newAppState) ||
-                                       (Exchange::IAppManager::AppLifecycleState::APP_STATE_ACTIVE == newAppState) ||
-                                       (Exchange::IAppManager::AppLifecycleState::APP_STATE_PAUSED == newAppState) ||
-                                       (Exchange::IAppManager::AppLifecycleState::APP_STATE_SUSPENDED == newAppState) ||
-                                       (Exchange::IAppManager::AppLifecycleState::APP_STATE_HIBERNATED == newAppState) ||
-                                       (Exchange::IAppManager::AppLifecycleState::APP_STATE_UNLOADED == newAppState));
+                                (Exchange::IAppManager::AppLifecycleState::APP_STATE_ACTIVE == newAppState) ||
+                                (Exchange::IAppManager::AppLifecycleState::APP_STATE_PAUSED == newAppState) ||
+                                (Exchange::IAppManager::AppLifecycleState::APP_STATE_SUSPENDED == newAppState) ||
+                                (Exchange::IAppManager::AppLifecycleState::APP_STATE_HIBERNATED == newAppState) ||
+                                (Exchange::IAppManager::AppLifecycleState::APP_STATE_UNLOADED == newAppState));
 
-                LOGINFO("shouldNotify %d for Appstate %u",shouldNotify, newAppState);
+                LOGINFO("shouldNotify %d for Appstate %u", shouldNotify, newAppState);
 
-                if(shouldNotify)
+                if (shouldNotify)
                 {
-                    if(Exchange::IAppManager::AppLifecycleState::APP_STATE_UNLOADED == newAppState)
-		    {
+                    if (Exchange::IAppManager::AppLifecycleState::APP_STATE_UNLOADED == newAppState)
+                    {
                         bool crashAbortPending = false;
                         auto pendingCrashAbortIter = mPendingCrashAbortByAppId.find(appId);
                         if ((mPendingCrashAbortByAppId.end() != pendingCrashAbortIter) && (true == pendingCrashAbortIter->second))
@@ -814,45 +814,44 @@ End:
                         const bool lifecycleManagerInitiatedKill =
                             (Exchange::IAppManager::AppLifecycleState::APP_STATE_TERMINATING == oldAppState);
 
-
                         if (crashAbortPending)
-			{
-			    LOGINFO("Terminate event due to app crash");
-			    appManagerImplInstance->handleOnAppLifecycleStateChanged(appId, appInstanceId, newAppState, oldAppState, Exchange::IAppManager::AppErrorReason::APP_ERROR_ABORT);
+                        {
+                            LOGINFO("Terminate event due to app crash");
+                            appManagerImplInstance->handleOnAppLifecycleStateChanged(appId, appInstanceId, newAppState, oldAppState, Exchange::IAppManager::AppErrorReason::APP_ERROR_ABORT);
                             const std::string storedInstanceId = AppInfoManager::getInstance().getAppInstanceId(appId);
                             if (false == storedInstanceId.empty())
                             {
                                 std::string crashReason = "Terminate event due to app crash";
                                 AppManagerTelemetryReporting::getInstance().reportAppCrashedTelemetry(appId, storedInstanceId, crashReason);
                             }
-			}
+                        }
                         else if (appManagerInitiatedKill || lifecycleManagerInitiatedKill)
-			{
-			    // Normal close: AppManager requested termination or LifecycleManager terminated via close flow.
-			    LOGINFO("Terminate event from plugin");
-			    appManagerImplInstance->handleOnAppLifecycleStateChanged(appId, appInstanceId, newAppState, oldAppState, Exchange::IAppManager::AppErrorReason::APP_ERROR_NONE);
-			}
-			else
-			{
-			    // Abnormal close: unload did not originate from close/terminate flow.
-			    LOGINFO("Terminate event due to app crash");
-			    appManagerImplInstance->handleOnAppLifecycleStateChanged(appId, appInstanceId, newAppState, oldAppState, Exchange::IAppManager::AppErrorReason::APP_ERROR_ABORT);
-                const std::string storedInstanceId = AppInfoManager::getInstance().getAppInstanceId(appId);
-                if (false == storedInstanceId.empty())
-                {
-                    std::string crashReason = "Terminate event due to app crash";
-                    AppManagerTelemetryReporting::getInstance().reportAppCrashedTelemetry(appId, storedInstanceId, crashReason);
-                }
-            }
-			mAppCurrentActionList.erase(appId);
-		    }
-		    else
-		    {
+                        {
+                            // Normal close: AppManager requested termination or LifecycleManager terminated via close flow.
+                            LOGINFO("Terminate event from plugin");
+                            appManagerImplInstance->handleOnAppLifecycleStateChanged(appId, appInstanceId, newAppState, oldAppState, Exchange::IAppManager::AppErrorReason::APP_ERROR_NONE);
+                        }
+                        else
+                        {
+                            // Abnormal close: unload did not originate from close/terminate flow.
+                            LOGINFO("Terminate event due to app crash");
+                            appManagerImplInstance->handleOnAppLifecycleStateChanged(appId, appInstanceId, newAppState, oldAppState, Exchange::IAppManager::AppErrorReason::APP_ERROR_ABORT);
+                            const std::string storedInstanceId = AppInfoManager::getInstance().getAppInstanceId(appId);
+                            if (false == storedInstanceId.empty())
+                            {
+                                std::string crashReason = "Terminate event due to app crash";
+                                AppManagerTelemetryReporting::getInstance().reportAppCrashedTelemetry(appId, storedInstanceId, crashReason);
+                            }
+                        }
+                        mAppCurrentActionList.erase(appId);
+                    }
+                    else
+                    {
                         appManagerImplInstance->handleOnAppLifecycleStateChanged(appId, appInstanceId, newAppState, oldAppState, Exchange::IAppManager::AppErrorReason::APP_ERROR_NONE);
-		    }
+                    }
                 }
 
-                if(Exchange::IAppManager::AppLifecycleState::APP_STATE_UNLOADED == newAppState)
+                if (Exchange::IAppManager::AppLifecycleState::APP_STATE_UNLOADED == newAppState)
                 {
                     appManagerImplInstance->handleOnAppUnloaded(appId, appInstanceId);
                 }

--- a/AppManager/LifecycleInterfaceConnector.h
+++ b/AppManager/LifecycleInterfaceConnector.h
@@ -117,6 +117,7 @@ namespace WPEFramework
                     std::mutex mStateMutex;
                     std::string mAppIdAwaitingPause;
 		    std::map<std::string, Exchange::IAppManager::AppLifecycleState> mAppCurrentActionList;
+                    std::map<std::string, bool> mPendingCrashAbortByAppId;
         };
     }
 }

--- a/LifecycleManager/LifecycleManagerImplementation.cpp
+++ b/LifecycleManager/LifecycleManagerImplementation.cpp
@@ -148,6 +148,11 @@ namespace WPEFramework
                      if (Exchange::ILifecycleManager::LifecycleState::UNLOADED == static_cast<Exchange::ILifecycleManager::LifecycleState>(newLifecycleState))
                      {
                          shouldRespawn = tryGetPendingRespawn(appInstanceId, pendingRespawn);
+                         string pendingUnloadErrorReason;
+                         if (true == tryGetPendingUnloadErrorReason(appInstanceId, pendingUnloadErrorReason))
+                         {
+                             errorReason = pendingUnloadErrorReason;
+                         }
                      }
                      while (index != mLifecycleManagerNotification.end())
                      {
@@ -667,6 +672,10 @@ namespace WPEFramework
                         context->setApplicationKillParams(false);
                         context->resetPendingStates();
 
+                        mAdminLock.Lock();
+                        mPendingUnloadErrorReasons[appInstanceId] = "ERROR_ABORT";
+                        mAdminLock.Unlock();
+
                         terminated = RequestHandler::getInstance()->terminate(context.get(), false, terminateError);
                         stateUpdated = RequestHandler::getInstance()->updateState(context.get(), context->getTargetLifecycleState(), updateError);
                         if(terminated && stateUpdated)
@@ -772,6 +781,19 @@ namespace WPEFramework
 
             pendingRespawn = pendingRespawnIter->second;
             mPendingRespawns.erase(pendingRespawnIter);
+            return true;
+        }
+
+        bool LifecycleManagerImplementation::tryGetPendingUnloadErrorReason(const string& appInstanceId, string& errorReason)
+        {
+            auto pendingUnloadErrorIter = mPendingUnloadErrorReasons.find(appInstanceId);
+            if (pendingUnloadErrorIter == mPendingUnloadErrorReasons.end())
+            {
+                return false;
+            }
+
+            errorReason = pendingUnloadErrorIter->second;
+            mPendingUnloadErrorReasons.erase(pendingUnloadErrorIter);
             return true;
         }
 

--- a/LifecycleManager/LifecycleManagerImplementation.h
+++ b/LifecycleManager/LifecycleManagerImplementation.h
@@ -149,6 +149,7 @@ namespace WPEFramework
 	        std::list<Exchange::ILifecycleManagerState::INotification*> mLifecycleManagerStateNotification;
                 std::list<std::shared_ptr<ApplicationContext>> mLoadedApplications;
                 std::map<string, PendingRespawnRequest> mPendingRespawns;
+                std::map<string, string> mPendingUnloadErrorReasons;
                 PluginHost::IShell* mService;
 	    private: /* internal methods */
                 bool initialize(PluginHost::IShell* service);
@@ -159,6 +160,7 @@ namespace WPEFramework
                 void notifyOnFailure(const string& appInstanceId, const string& errorCode);
                 void handleStateChangeEvent(const JsonObject &data);
                 bool tryGetPendingRespawn(const string& appInstanceId, PendingRespawnRequest& pendingRespawn);
+                bool tryGetPendingUnloadErrorReason(const string& appInstanceId, string& errorReason);
                 void handlePendingRespawn(const PendingRespawnRequest& pendingRespawn);
                 void handleWindowManagerEvent(const JsonObject &data);
                 std::shared_ptr<ApplicationContext> getContext(const string& appInstanceId, const string& appId) const;

--- a/Tests/L0Tests/LifecycleManager/LifecycleManager_ContextTests.cpp
+++ b/Tests/L0Tests/LifecycleManager/LifecycleManager_ContextTests.cpp
@@ -54,6 +54,7 @@ namespace {
         void onRippleEvent(std::string, WPEFramework::Core::JSON::VariantContainer&) override {}
         void onStateChangeEvent(WPEFramework::Core::JSON::VariantContainer&) override {}
     };
+
     static StubEventHandler  gStubEventHandler;
     static L0Test::FakeRuntimeManager gCtxTestRtm;
     static L0Test::FakeWindowManager  gCtxTestWm;

--- a/Tests/L0Tests/LifecycleManager/LifecycleManager_ImplementationTests.cpp
+++ b/Tests/L0Tests/LifecycleManager/LifecycleManager_ImplementationTests.cpp
@@ -1176,6 +1176,9 @@ uint32_t Test_Impl_CloseAppKillAndRunDefersRespawnUntilUnloaded()
     L0Test::TestResult tr;
 
     RespawnTrackingLifecycleManagerImpl impl;
+    L0Test::FakeLcmStateNotification* stateNotification = new L0Test::FakeLcmStateNotification();
+
+    impl.Register(static_cast<WPEFramework::Exchange::ILifecycleManagerState::INotification*>(stateNotification));
 
     auto ctx = std::make_shared<WPEFramework::Plugin::ApplicationContext>("com.test.respawn");
     std::string inst = "inst-respawn-001";
@@ -1228,6 +1231,11 @@ uint32_t Test_Impl_CloseAppKillAndRunDefersRespawnUntilUnloaded()
         LifecycleManagerImplementationTest::EventNames::LIFECYCLE_MANAGER_EVENT_APPSTATECHANGED,
         params);
 
+    L0Test::ExpectEqStr(tr,
+        stateNotification->lastNavigationIntent,
+        "",
+        "UNLOADED state notification keeps navigationIntent unchanged for close flow");
+
     L0Test::ExpectTrue(tr,
         LifecycleManagerImplementationTest::getLoadedApps(impl).empty(),
         "old app context is removed after the UNLOADED event");
@@ -1243,6 +1251,9 @@ uint32_t Test_Impl_CloseAppKillAndRunDefersRespawnUntilUnloaded()
         static_cast<uint32_t>(LifecycleManagerImplementationTest::getPendingRespawnCount(impl)),
         0u,
         "pending respawn is cleared after unload confirmation");
+
+    impl.Unregister(static_cast<WPEFramework::Exchange::ILifecycleManagerState::INotification*>(stateNotification));
+    stateNotification->Release();
 
     return tr.failures;
 }

--- a/Tests/L1Tests/tests/test_AppManager.cpp
+++ b/Tests/L1Tests/tests/test_AppManager.cpp
@@ -4477,6 +4477,120 @@ TEST_F(AppManagerTest, LICMapAppLifecycleStateUnloaded)
 }
 
 /*
+ * Test Case for LICTerminatingToUnloadedWithoutCrashSignalReportsNone
+ * Setting up AppManager Plugin with full resources
+ * Pre-populating mAppInfo and triggering OnAppLifecycleStateChanged with TERMINATING->UNLOADED
+ * Verifying expected terminate flow reports APP_ERROR_NONE without using navigationIntent markers
+ * Releasing the AppManager interface and all related test resources
+ */
+TEST_F(AppManagerTest, LICTerminatingToUnloadedWithoutCrashSignalReportsNone)
+{
+    Core::hresult status;
+    status = createResources();
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    AppInfoManager::getInstance().upsert(APPMANAGER_APP_ID, [](AppInfo& a) {
+        a.setAppInstanceId(APPMANAGER_APP_INSTANCE);
+        a.setAppNewState(Exchange::IAppManager::AppLifecycleState::APP_STATE_TERMINATING);
+    });
+
+    ASSERT_NE(mLifecycleManagerStateNotification_cb, nullptr)
+        << "LifecycleManagerState notification callback is not registered";
+
+    uint32_t signalled = AppManager_StateInvalid;
+    ExpectedAppLifecycleEvent expectedEvent;
+    expectedEvent.appId = APPMANAGER_APP_ID;
+    expectedEvent.appInstanceId = APPMANAGER_APP_INSTANCE;
+    expectedEvent.newState = Exchange::IAppManager::AppLifecycleState::APP_STATE_UNLOADED;
+    expectedEvent.oldState = Exchange::IAppManager::AppLifecycleState::APP_STATE_TERMINATING;
+    expectedEvent.errorReason = Exchange::IAppManager::AppErrorReason::APP_ERROR_NONE;
+
+    Core::Sink<NotificationHandler> notification;
+    mAppManagerImpl->Register(&notification);
+    notification.SetExpectedEvent(expectedEvent);
+
+    mLifecycleManagerStateNotification_cb->OnAppLifecycleStateChanged(
+        APPMANAGER_APP_ID,
+        APPMANAGER_APP_INSTANCE,
+        Exchange::ILifecycleManager::LifecycleState::TERMINATING, /* old */
+        Exchange::ILifecycleManager::LifecycleState::UNLOADED,    /* new */
+        ""
+    );
+
+    signalled = notification.WaitForRequestStatus(TIMEOUT, AppManager_onAppUnloaded);
+    EXPECT_TRUE(signalled & AppManager_onAppLifecycleStateChanged);
+    EXPECT_TRUE(signalled & AppManager_onAppUnloaded);
+
+    mAppManagerImpl->Unregister(&notification);
+
+    if (status == Core::ERROR_NONE)
+    {
+        releaseResources();
+    }
+}
+
+/*
+ * Test Case for LICTerminatingToUnloadedWithAbortSignalReportsAbort
+ * Setting up AppManager Plugin with full resources
+ * Pre-populating mAppInfo, delivering OnAppStateChanged(ERROR_ABORT), then TERMINATING->UNLOADED
+ * Verifying crash path reports APP_ERROR_ABORT without navigationIntent marker usage
+ * Releasing the AppManager interface and all related test resources
+ */
+TEST_F(AppManagerTest, LICTerminatingToUnloadedWithAbortSignalReportsAbort)
+{
+    Core::hresult status;
+    status = createResources();
+    EXPECT_EQ(Core::ERROR_NONE, status);
+
+    AppInfoManager::getInstance().upsert(APPMANAGER_APP_ID, [](AppInfo& a) {
+        a.setAppInstanceId(APPMANAGER_APP_INSTANCE);
+        a.setAppNewState(Exchange::IAppManager::AppLifecycleState::APP_STATE_TERMINATING);
+    });
+
+    ASSERT_NE(mLifecycleManagerStateNotification_cb, nullptr)
+        << "LifecycleManagerState notification callback is not registered";
+
+    ASSERT_NE(Plugin::LifecycleInterfaceConnector::_instance, nullptr)
+        << "LifecycleInterfaceConnector instance is not set";
+
+    uint32_t signalled = AppManager_StateInvalid;
+    ExpectedAppLifecycleEvent expectedEvent;
+    expectedEvent.appId = APPMANAGER_APP_ID;
+    expectedEvent.appInstanceId = APPMANAGER_APP_INSTANCE;
+    expectedEvent.newState = Exchange::IAppManager::AppLifecycleState::APP_STATE_UNLOADED;
+    expectedEvent.oldState = Exchange::IAppManager::AppLifecycleState::APP_STATE_TERMINATING;
+    expectedEvent.errorReason = Exchange::IAppManager::AppErrorReason::APP_ERROR_ABORT;
+
+    Core::Sink<NotificationHandler> notification;
+    mAppManagerImpl->Register(&notification);
+    notification.SetExpectedEvent(expectedEvent);
+
+    Plugin::LifecycleInterfaceConnector::_instance->OnAppStateChanged(
+        APPMANAGER_APP_ID,
+        Exchange::ILifecycleManager::LifecycleState::TERMINATING,
+        "ERROR_ABORT");
+
+    mLifecycleManagerStateNotification_cb->OnAppLifecycleStateChanged(
+        APPMANAGER_APP_ID,
+        APPMANAGER_APP_INSTANCE,
+        Exchange::ILifecycleManager::LifecycleState::TERMINATING, /* old */
+        Exchange::ILifecycleManager::LifecycleState::UNLOADED,    /* new */
+        ""
+    );
+
+    signalled = notification.WaitForRequestStatus(TIMEOUT, AppManager_onAppUnloaded);
+    EXPECT_TRUE(signalled & AppManager_onAppLifecycleStateChanged);
+    EXPECT_TRUE(signalled & AppManager_onAppUnloaded);
+
+    mAppManagerImpl->Unregister(&notification);
+
+    if (status == Core::ERROR_NONE)
+    {
+        releaseResources();
+    }
+}
+
+/*
  * Test Case for LICMapAppLifecycleStateInitializing
  * Setting up AppManager Plugin with full resources
  * Pre-populating mAppInfo and triggering OnAppLifecycleStateChanged with LOADING->INITIALIZING


### PR DESCRIPTION
- Add lifecycle close markers for user exit and termination scenarios.
- Update OnAppLifecycleStateChanged to classify app unloads correctly based on close markers.
- Implement tests to verify behavior for unloading without close markers and with specific close markers.