### PR TITLE
RDKEMW-15356 : Uninitialized scalar read in InitializeState() causes nondeterministic startup

### DIFF
--- a/PackageManager/PackageManagerImplementation.cpp
+++ b/PackageManager/PackageManagerImplementation.cpp
@@ -841,6 +841,10 @@ namespace Plugin {
         runtimeConfig.appPath = config.appPath;
         runtimeConfig.command = config.command;
         runtimeConfig.runtimePath = config.runtimePath;
+        runtimeConfig.enableDebugger = config.enableDebugger;
+        runtimeConfig.logFileMaxSize = config.logFileMaxSize;
+        runtimeConfig.mapi = config.mapi;
+        runtimeConfig.resourceManagerClientEnabled = config.resourceManagerClientEnabled;
         runtimeConfig.ralfPkgPath = config.ralfPkgPath;
         runtimeConfig.logFilePath = config.logFilePath;
     }

--- a/PackageManager/PackageManagerImplementation.h
+++ b/PackageManager/PackageManagerImplementation.h
@@ -66,10 +66,10 @@ class PackageManagerImplementation
             };
 
             public:
-            State() {}
+            State() {};
             InstallState installState = InstallState::UNINSTALLED;
             uint32_t mLockCount = 0;
-            Exchange::RuntimeConfig runtimeConfig;
+            Exchange::RuntimeConfig runtimeConfig {};
             string digest;
             string gatewayMetadataPath;
             string unpackedPath;

--- a/PackageManager/PackageManagerImplementation.h
+++ b/PackageManager/PackageManagerImplementation.h
@@ -66,7 +66,7 @@ class PackageManagerImplementation
             };
 
             public:
-            State() {};
+            State() {}
             InstallState installState = InstallState::UNINSTALLED;
             uint32_t mLockCount = 0;
             Exchange::RuntimeConfig runtimeConfig {};


### PR DESCRIPTION
Initialized RuntimeConfig members to fix uninitialized scalar reads in InitializeState().