### PR TITLE
RDKEMW-20906: RDKWindowManager.getApps Result Contains Escape Charact…

### DIFF
--- a/RDKWindowManager/RDKWindowManager.md
+++ b/RDKWindowManager/RDKWindowManager.md
@@ -105,7 +105,7 @@ interface IRDKWindowManager {
                           bool virtualDisplay, uint32_t virtualWidth, uint32_t virtualHeight,
                           uint32_t ownerId, uint32_t groupId,
                           bool topmost, bool focus);
-    hresult GetApps(string& appIds) const;
+    hresult GetApps(IStringIterator*& appsIds) const;
 
     // Key Management
     hresult AddKeyIntercept(const string& intercept);

--- a/RDKWindowManager/RDKWindowManagerImplementation.cpp
+++ b/RDKWindowManager/RDKWindowManagerImplementation.cpp
@@ -755,16 +755,16 @@ Core::hresult RDKWindowManagerImplementation::CreateDisplay(const string &client
  * @brief Get the list of connected application clients.
  * Returns a list of application IDs currently connected to the window manager.
  *
- * @appsIds[out]      : JSON string array of connected app IDs.
- *                      Ex: [\"org.rdk.youttube\",\"org.rdk.netflix\"]
+ * @appsIds[out]      : Iterator over the connected app IDs (JSON-RPC serializes this as a JSON array).
+ *                      Ex: ["org.rdk.youtube","org.rdk.netflix"]
  * @return Core::ERROR_NONE on success, Core::ERROR_GENERAL on error.
  */
-Core::hresult RDKWindowManagerImplementation::GetApps(string &appsIds) const
+Core::hresult RDKWindowManagerImplementation::GetApps(IStringIterator*& appsIds) const
 {
+    appsIds = nullptr;
     Core::hresult status = Core::ERROR_GENERAL;
     bool retValue = false;
     std::vector<std::string> clientList;
-    JsonArray clientsArray;
     bool lockAcquired = false;
 
     lockAcquired = lockRdkWindowManagerMutex();
@@ -773,24 +773,23 @@ Core::hresult RDKWindowManagerImplementation::GetApps(string &appsIds) const
         retValue = CompositorController::getClients(clientList);
         gRdkWindowManagerMutex.unlock();
     }
+    else
+    {
+        LOGERR("Failed to acquire RDKWindowManager mutex in GetApps");
+    }
 
     if (true == retValue)
     {
-        for (size_t i = 0; i < clientList.size(); i++)
+        appsIds = Core::Service<RPC::StringIterator>::Create<IStringIterator>(clientList);
+        if (nullptr != appsIds)
         {
-            clientsArray.Add(clientList[i]);
-        }
-
-        if (clientsArray.IsSet())
-        {
-            clientsArray.ToString(appsIds);
-            LOGINFO("List of appsIds: %s", appsIds.c_str());
+            LOGINFO("List of appsIds count: %zu", clientList.size());
+            status = Core::ERROR_NONE;
         }
         else
         {
-            LOGWARN("There are no apps");
+            LOGERR("GetApps Failed to allocate iterator");
         }
-        status = Core::ERROR_NONE;
     }
     else
     {

--- a/RDKWindowManager/RDKWindowManagerImplementation.h
+++ b/RDKWindowManager/RDKWindowManagerImplementation.h
@@ -129,7 +129,7 @@ namespace Plugin {
         Core::hresult Register(INotification *notification) override;
         Core::hresult Unregister(INotification *notification) override;
         Core::hresult CreateDisplay(const string &clientId, const string &displayName, const uint32_t displayWidth, const uint32_t displayHeight, const bool virtualDisplay, const uint32_t virtualWidth, const uint32_t virtualHeight, const uint32_t ownerId, const uint32_t groupId, const bool topmost, const bool focus, const string &capabilities) override;
-        Core::hresult GetApps(string &appsIds) const override;
+        Core::hresult GetApps(IStringIterator*& appsIds) const override;
         Core::hresult AddKeyIntercept(const string &intercept) override;
         Core::hresult AddKeyIntercepts(const string &clientId, const string &intercepts) override;
         Core::hresult RemoveKeyIntercept(const string &clientId, uint32_t keyCode, const string &modifiers) override;

--- a/Tests/L0Tests/LifecycleManager/LifecycleManagerServiceMock.h
+++ b/Tests/L0Tests/LifecycleManager/LifecycleManagerServiceMock.h
@@ -157,7 +157,7 @@ public:
         const bool /*topmost*/, const bool /*focus*/,
         const string& /*capabilities*/) override { return WPEFramework::Core::ERROR_NONE; }
 
-    WPEFramework::Core::hresult GetApps(string& /*appsIds*/) const override { return WPEFramework::Core::ERROR_NONE; }
+    WPEFramework::Core::hresult GetApps(WPEFramework::Exchange::IRDKWindowManager::IStringIterator*& appsIds) const override { appsIds = nullptr; return WPEFramework::Core::ERROR_NONE; }
     WPEFramework::Core::hresult AddKeyIntercept(const string& /*intercept*/) override { return WPEFramework::Core::ERROR_NONE; }
     WPEFramework::Core::hresult AddKeyIntercepts(const string& /*clientId*/, const string& /*intercepts*/) override { return WPEFramework::Core::ERROR_NONE; }
     WPEFramework::Core::hresult RemoveKeyIntercept(const string& /*clientId*/, uint32_t /*keyCode*/, const string& /*modifiers*/) override { return WPEFramework::Core::ERROR_NONE; }

--- a/Tests/L0Tests/RDKWindowManager/RDKWindowManager_ImplementationTests.cpp
+++ b/Tests/L0Tests/RDKWindowManager/RDKWindowManager_ImplementationTests.cpp
@@ -214,12 +214,20 @@ uint32_t Test_RDKWM_Impl_GetAppsAndFocusPaths()
     auto* impl = CreateImpl();
     L0Test::RDKWMShim::Reset();
 
-    std::string apps;
+    WPEFramework::Exchange::IRDKWindowManager::IStringIterator* apps = nullptr;
     L0Test::RDKWMShim::SetGetClientsResult(true, { "alpha", "beta" });
     const auto appsRc = impl->GetApps(apps);
     L0Test::ExpectEqU32(tr, appsRc, WPEFramework::Core::ERROR_NONE,
         "GetApps returns ERROR_NONE when shim getClients succeeds");
-    L0Test::ExpectTrue(tr, apps.find("alpha") != std::string::npos,
+    bool foundAlpha = false;
+    if (apps != nullptr) {
+        std::string element;
+        while (apps->Next(element)) {
+            if (element == "alpha") { foundAlpha = true; }
+        }
+        apps->Release();
+    }
+    L0Test::ExpectTrue(tr, foundAlpha,
         "GetApps output contains alpha");
 
     L0Test::RDKWMShim::SetSetFocusResult(true);
@@ -646,10 +654,11 @@ uint32_t Test_RDKWM_Impl_ErrorPathMatrix()
     L0Test::RDKWMShim::Reset();
 
     L0Test::RDKWMShim::SetGetClientsResult(false, {});
-    std::string apps;
+    WPEFramework::Exchange::IRDKWindowManager::IStringIterator* apps = nullptr;
     const auto getAppsFailRc = impl->GetApps(apps);
     L0Test::ExpectEqU32(tr, getAppsFailRc, WPEFramework::Core::ERROR_GENERAL,
         "GetApps returns ERROR_GENERAL when backend getClients fails");
+    if (apps != nullptr) { apps->Release(); }
 
     const auto setVisibleEmptyRc = impl->SetVisible("", true);
     L0Test::ExpectEqU32(tr, setVisibleEmptyRc, WPEFramework::Core::ERROR_GENERAL,

--- a/Tests/L0Tests/RDKWindowManager/RDKWindowManager_LifecycleTests.cpp
+++ b/Tests/L0Tests/RDKWindowManager/RDKWindowManager_LifecycleTests.cpp
@@ -58,7 +58,7 @@ public:
     WPEFramework::Core::hresult Deinitialize(WPEFramework::PluginHost::IShell*) override { return WPEFramework::Core::ERROR_NONE; }
 
     WPEFramework::Core::hresult CreateDisplay(const std::string&, const std::string&, uint32_t, uint32_t, bool, uint32_t, uint32_t, uint32_t, uint32_t, bool, bool, const std::string&) override { return WPEFramework::Core::ERROR_NONE; }
-    WPEFramework::Core::hresult GetApps(std::string&) const override { return WPEFramework::Core::ERROR_NONE; }
+    WPEFramework::Core::hresult GetApps(WPEFramework::Exchange::IRDKWindowManager::IStringIterator*& appsIds) const override { appsIds = nullptr; return WPEFramework::Core::ERROR_NONE; }
     WPEFramework::Core::hresult AddKeyIntercept(const std::string&) override { return WPEFramework::Core::ERROR_NONE; }
     WPEFramework::Core::hresult AddKeyIntercepts(const std::string&, const std::string&) override { return WPEFramework::Core::ERROR_NONE; }
     WPEFramework::Core::hresult RemoveKeyIntercept(const std::string&, uint32_t, const std::string&) override { return WPEFramework::Core::ERROR_NONE; }

--- a/Tests/L0Tests/RuntimeManager/ServiceMock.h
+++ b/Tests/L0Tests/RuntimeManager/ServiceMock.h
@@ -379,7 +379,7 @@ public:
         return _createDisplayReturnCode;
     }
 
-    WPEFramework::Core::hresult GetApps(string& /*appsIds*/) const override { return WPEFramework::Core::ERROR_NONE; }
+    WPEFramework::Core::hresult GetApps(WPEFramework::Exchange::IRDKWindowManager::IStringIterator*& appsIds) const override { appsIds = nullptr; return WPEFramework::Core::ERROR_NONE; }
     WPEFramework::Core::hresult AddKeyIntercept(const string& /*intercept*/) override { return WPEFramework::Core::ERROR_NONE; }
     WPEFramework::Core::hresult AddKeyIntercepts(const string& /*clientId*/, const string& /*intercepts*/) override { return WPEFramework::Core::ERROR_NONE; }
     WPEFramework::Core::hresult RemoveKeyIntercept(const string& /*clientId*/, const uint32_t /*keyCode*/, const string& /*modifiers*/) override { return WPEFramework::Core::ERROR_NONE; }

--- a/Tests/L1Tests/WindowManagerMock.h
+++ b/Tests/L1Tests/WindowManagerMock.h
@@ -44,7 +44,7 @@ public:
          const bool topmost, const bool focus, const string& capabilities),
         (override));
 
-    MOCK_METHOD(WPEFramework::Core::hresult, GetApps, (string& appsIds), (const, override));
+    MOCK_METHOD(WPEFramework::Core::hresult, GetApps, (WPEFramework::Exchange::IRDKWindowManager::IStringIterator*& appsIds), (const, override));
     MOCK_METHOD(WPEFramework::Core::hresult, AddKeyIntercept, (const string& intercept), (override));
     MOCK_METHOD(WPEFramework::Core::hresult, AddKeyIntercepts, (const string& clientId, const string& intercepts), (override));
     MOCK_METHOD(WPEFramework::Core::hresult, RemoveKeyIntercept, (const string& clientId, uint32_t keyCode, const string& modifiers), (override));

--- a/Tests/L1Tests/tests/test_RDKWindowManager.cpp
+++ b/Tests/L1Tests/tests/test_RDKWindowManager.cpp
@@ -267,15 +267,22 @@ TEST_F(RDKWindowManagerTest, CreateDisplay_Failure)
  * ===================================================================== */
 TEST_F(RDKWindowManagerTest, GetApps_Success)
 {
-    const string expectedApps = R"(["testApp","anotherApp"])";
+    std::vector<string> expectedApps = { "testApp", "anotherApp" };
     EXPECT_CALL(*windowManagerMock, GetApps(_))
-        .WillOnce(Invoke([&](string& appsIds) {
-            appsIds = expectedApps;
+        .WillOnce(Invoke([&](RPC::IStringIterator*& appsIds) {
+            appsIds = Core::Service<RPC::StringIterator>::Create<RPC::IStringIterator>(expectedApps);
             return Core::ERROR_NONE;
         }));
 
     EXPECT_EQ(Core::ERROR_NONE,
         handler.Invoke(connection, _T("getApps"), _T("{}"), response));
+
+    // Verify the result is a native JSON array, not a JSON-encoded string.
+    // The old bug produced escaped JSON like: "appsIds":"[\"testApp\",\"anotherApp\"]"
+    // The fix must produce a native array: "appsIds":["testApp","anotherApp"]
+    EXPECT_EQ(string::npos, response.find("\\\""));
+    EXPECT_NE(string::npos, response.find("testApp"));
+    EXPECT_NE(string::npos, response.find("anotherApp"));
 }
 
 TEST_F(RDKWindowManagerTest, GetApps_Failure)
@@ -1362,7 +1369,7 @@ TEST_F(RDKWindowManagerImplementationTest, Impl_CreateDisplay_EmptyParams_Failur
 
 TEST_F(RDKWindowManagerImplementationTest, Impl_GetApps_Success)
 {
-    string apps;
+    RPC::IStringIterator* apps = nullptr;
     EXPECT_CALL(compositorMock, getClients(_))
         .WillOnce(Invoke([](std::vector<std::string>& clients) {
             clients = { "testapp", "anotherapp" };
@@ -1370,15 +1377,25 @@ TEST_F(RDKWindowManagerImplementationTest, Impl_GetApps_Success)
         }));
 
     EXPECT_EQ(Core::ERROR_NONE, windowManagerImplementation->GetApps(apps));
+    ASSERT_NE(apps, nullptr);
+    string element;
+    std::vector<string> received;
+    while (apps->Next(element)) {
+        received.push_back(element);
+    }
+    apps->Release();
+    EXPECT_THAT(received, ::testing::ElementsAre("testapp", "anotherapp"));
 }
 
 TEST_F(RDKWindowManagerImplementationTest, Impl_GetApps_Failure)
 {
-    string apps;
+    RPC::IStringIterator* apps = nullptr;
     EXPECT_CALL(compositorMock, getClients(_))
         .WillOnce(Return(false));
 
     EXPECT_EQ(Core::ERROR_GENERAL, windowManagerImplementation->GetApps(apps));
+    // On failure the out-param must remain nullptr so callers can safely skip Release().
+    EXPECT_EQ(apps, nullptr);
 }
 
 TEST_F(RDKWindowManagerImplementationTest, Impl_EnableInputEvents_InvalidJson_Failure)

--- a/Tests/mocks/WindowManagerMock.h
+++ b/Tests/mocks/WindowManagerMock.h
@@ -33,7 +33,7 @@ public:
     MOCK_METHOD(WPEFramework::Core::hresult, Initialize, (WPEFramework::PluginHost::IShell* service), (override));
     MOCK_METHOD(WPEFramework::Core::hresult, Deinitialize, (WPEFramework::PluginHost::IShell* service), (override));
     MOCK_METHOD(WPEFramework::Core::hresult, CreateDisplay, (const string& displayParams), (override));
-    MOCK_METHOD(WPEFramework::Core::hresult, GetApps, (string& appsIds), (const, override));
+    MOCK_METHOD(WPEFramework::Core::hresult, GetApps, (WPEFramework::Exchange::IRDKWindowManager::IStringIterator*& appsIds), (const, override));
     MOCK_METHOD(WPEFramework::Core::hresult, AddKeyIntercept, (const string &intercept), (override));
     MOCK_METHOD(WPEFramework::Core::hresult, AddKeyIntercepts, (const string &clientId, const string &intercepts), (override));
     MOCK_METHOD(WPEFramework::Core::hresult, RemoveKeyIntercept, (const string &clientId, uint32_t keyCode, const string &modifiers), (override));

--- a/build_dependencies.sh
+++ b/build_dependencies.sh
@@ -67,7 +67,7 @@ git clone --branch  R4.4.3 https://github.com/rdkcentral/ThunderTools.git
 
 git clone --branch R4.4.1 https://github.com/rdkcentral/Thunder.git
 
-git clone --branch topic/RDKEMW-19574 https://github.com/rdkcentral/entservices-apis.git
+git clone --branch topic/RDKEMW-19867 https://github.com/rdkcentral/entservices-apis.git
 
 
 git clone -b develop https://github.com/rdkcentral/eshelpers.git


### PR DESCRIPTION
…ers (#503)

* RDKEMW-20906: Update output parameter to StringIterator to remove stringification

* RDKEMW-20906: Update L0 and L1 tests

* Updated comment

* Fixing comments in getApps



* GetApps: initialize out-param to nullptr and log mutex acquisition failure

* GetApps: address Copilot review suggestions

- Impl: guard ERROR_NONE behind appsIds != nullptr check to avoid crash on iterator allocation failure (Copilot: medium)
- Impl: initialize appsIds out-param to nullptr at function entry (Copilot: medium)
- Impl: log mutex acquisition failure in GetApps error path (Copilot: medium)
- Test (L1): validate getApps response is native JSON array not escaped string (Copilot: low)
- Test (L1): assert out-param stays nullptr on GetApps failure path (Copilot: low)
- Mocks: initialize appsIds to nullptr in all fake GetApps overrides (LifecycleManagerServiceMock, RDKWindowManager_LifecycleTests, RuntimeManager/ServiceMock) to avoid indeterminate pointer (Copilot: medium)

* Updating line 784 to keep YODA consistency



* GetApps: address remaining Copilot review suggestions

- Mocks: update Tests/mocks/WindowManagerMock.h GetApps signature from
  string& to RPC::IStringIterator*& to match updated interface (Copilot: high)
- Test (L1): replace EXPECT_EQ(size) with EXPECT_THAT(ElementsAre) in
  Impl_GetApps_Success to verify exact iterator contents, not just count (Copilot: low)

* fix: use IStringIterator alias in RDKWindowManager implementation

Replace RPC::IStringIterator with the IStringIterator nested type alias defined in IRDKWindowManager, consistent with RuntimeManager pattern.

* Update doc

* fix: update IStringIterator usage in L0 tests and docs to use new alias

Replace WPEFramework::RPC::IStringIterator with the IStringIterator alias defined in IRDKWindowManager, using each file's existing qualification style for consistency. Also update RDKWindowManager.md to match.

* L0 fixes 1

---------