### PR TITLE
RDKEMW-20212: AppPackageManager.uninstall reports wrong error 

### DIFF
--- a/PackageManager/PackageManagerImplementation.cpp
+++ b/PackageManager/PackageManagerImplementation.cpp
@@ -615,9 +615,11 @@ namespace Plugin {
             } // mLockCount == 0
         } else {
             LOGERR("Package: %s Version: %s Not found", packageId.c_str(), version.c_str());
-            result = Core::ERROR_BAD_REQUEST;
-            packageFailureErrorCode = PackageManagerImplementation::PackageFailureErrorCode::ERROR_VERSION_NOT_FOUND;
 
+            result = Core::ERROR_GENERAL;
+
+            packageFailureErrorCode =
+                PackageManagerImplementation::PackageFailureErrorCode::ERROR_VERSION_NOT_FOUND;
         }
 
         recordAndPublishTelemetryData(((PackageManagerImplementation::PackageFailureErrorCode::ERROR_NONE == packageFailureErrorCode) ? TELEMETRY_MARKER_UNINSTALL_TIME : TELEMETRY_MARKER_UNINSTALL_ERROR),

--- a/Tests/L0Tests/PackageManager/PackageManager_ImplementationTests.cpp
+++ b/Tests/L0Tests/PackageManager/PackageManager_ImplementationTests.cpp
@@ -516,8 +516,8 @@ uint32_t Test_PM_Impl_InstallInputValidationAndUnknownPaths()
     std::string reason;
     L0Test::ExpectEqU32(tr,
                         fx.impl->Uninstall("NoSuchApp", reason),
-                        ERROR_BAD_REQUEST,
-                        "Uninstall() for unknown app returns ERROR_BAD_REQUEST");
+                        ERROR_GENERAL,
+                        "Uninstall() for unknown app returns ERROR_GENERAL");
 
     WPEFramework::Exchange::RuntimeConfig cfg {};
     L0Test::ExpectEqU32(tr,

--- a/Tests/L1Tests/tests/test_PackageManager.cpp
+++ b/Tests/L1Tests/tests/test_PackageManager.cpp
@@ -1982,7 +1982,7 @@ TEST_F(PackageManagerTest, configAndPackageStateNegativeBranchesusingComRpc) {
 /* Test Case for uninstall unknown package branch using ComRpc
  *
  * Set up and initialize COM-RPC resources
- * Call Uninstall() for a package that does not exist and verify ERROR_BAD_REQUEST
+ * Call Uninstall() for a package that does not exist and verify ERROR_GENERAL
  * Deinitialize COM-RPC resources
  */
 
@@ -1993,7 +1993,7 @@ TEST_F(PackageManagerTest, uninstallUnknownPackageusingComRpcFailure) {
     waitforSignal(TIMEOUT_FOR_INIT);
 
     string errorReason;
-    EXPECT_EQ(Core::ERROR_BAD_REQUEST, pkginstallerInterface->Uninstall("UnknownApp", errorReason));
+    EXPECT_EQ(Core::ERROR_GENERAL, pkginstallerInterface->Uninstall("UnknownApp", errorReason));
 
     deinitforComRpc();
 }


### PR DESCRIPTION
AppPackageManager.uninstall reports wrong error while attempting to unistall an app which is not available